### PR TITLE
Add ActionCommand::SetFieldState

### DIFF
--- a/kodecks-bevy/src/scene/game/board.rs
+++ b/kodecks-bevy/src/scene/game/board.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use kodecks::{
     action,
     env::LocalEnvironment,
-    field::{FieldBattleState, FieldCardState},
+    field::{FieldBattleState, FieldState},
     id::ObjectId,
     phase::Phase,
     player::{PlayerId, PlayerZone},
@@ -49,9 +49,9 @@ impl From<action::AvailableActionList> for AvailableActionList {
 #[derive(Resource, Default)]
 pub struct Board {
     pub player_hand: Vec<ObjectId>,
-    pub player_field: Vec<(ObjectId, FieldCardState)>,
+    pub player_field: Vec<(ObjectId, FieldState)>,
     pub opponent_hand: Vec<ObjectId>,
-    pub opponent_field: Vec<(ObjectId, FieldCardState)>,
+    pub opponent_field: Vec<(ObjectId, FieldState)>,
 
     attackers: Vec<ObjectId>,
     blocking_pairs: Vec<(ObjectId, ObjectId)>,

--- a/kodecks-bevy/src/scene/game/main/card/frame.rs
+++ b/kodecks-bevy/src/scene/game/main/card/frame.rs
@@ -1,7 +1,7 @@
 use super::Card;
 use crate::scene::game::board::{AvailableActionList, Board};
 use bevy::prelude::*;
-use kodecks::field::FieldCardState;
+use kodecks::field::FieldState;
 
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CardFrame {
@@ -137,7 +137,7 @@ pub fn update_frame_overlay(
             .player_field
             .iter()
             .chain(board.opponent_field.iter())
-            .any(|(card, state)| card == &id && state == &FieldCardState::Exhausted);
+            .any(|(card, state)| card == &id && state == &FieldState::Exhausted);
         let selectable = list.selectable_cards().iter().any(|card| *card == id);
         if *frame == CardFrame::Shadow {
             let castable = list.castable_cards().iter().any(|card| *card == id);

--- a/kodecks/src/command.rs
+++ b/kodecks/src/command.rs
@@ -3,6 +3,7 @@ use crate::{
     env::Environment,
     error::Error,
     event::{CardEvent, EventReason},
+    field::FieldState,
     id::ObjectId,
     opcode::{Opcode, OpcodeList},
     player::PlayerId,
@@ -19,6 +20,12 @@ pub enum ActionCommand {
     DestroyCard {
         source: ObjectId,
         target: ObjectId,
+        reason: EventReason,
+    },
+    SetFieldState {
+        source: ObjectId,
+        target: ObjectId,
+        state: FieldState,
         reason: EventReason,
     },
     GenerateShards {
@@ -52,6 +59,12 @@ impl ActionCommand {
                 let source = env.state.find_card(source)?;
                 let target = env.state.find_card(target)?;
                 env.apply_event(CardEvent::Destroyed { reason }, source, target)
+            }
+            ActionCommand::SetFieldState { target, state, .. } => {
+                Ok(vec![OpcodeList::new(vec![Opcode::SetFieldState {
+                    card: target,
+                    state,
+                }])])
             }
             ActionCommand::GenerateShards {
                 player,

--- a/kodecks/src/env/local.rs
+++ b/kodecks/src/env/local.rs
@@ -3,7 +3,7 @@ use crate::{
     action::{Action, AvailableActionList, PlayerAvailableActions},
     card::CardSnapshot,
     error::Error,
-    field::{FieldCardState, FieldItem},
+    field::{FieldState, FieldItem},
     game::Report,
     id::ObjectId,
     phase::Phase,
@@ -58,7 +58,7 @@ impl LocalEnvironment {
             if let Some(card) = CardZone::remove(&mut player.hand, card) {
                 player.field.push(FieldItem {
                     card,
-                    state: FieldCardState::Active,
+                    state: FieldState::Active,
                     battle: None,
                 });
             }

--- a/kodecks/src/env/opcode.rs
+++ b/kodecks/src/env/opcode.rs
@@ -3,7 +3,7 @@ use crate::{
     ability::PlayerAbility,
     effect::{EffectActivateContext, EffectTriggerContext},
     error::Error,
-    field::FieldCardState,
+    field::FieldState,
     log::LogAction,
     opcode::Opcode,
     player::PlayerZone,
@@ -210,7 +210,7 @@ impl Environment {
 
                 Ok(log)
             }
-            Opcode::SetFieldCardState { card, state } => {
+            Opcode::SetFieldState { card, state } => {
                 for player in self.state.players.iter_mut() {
                     player.field.set_card_state(*card, *state);
                 }
@@ -226,7 +226,7 @@ impl Environment {
                 for player in self.state.players.iter_mut() {
                     for item in player.field.items_mut() {
                         if item.battle.is_none() {
-                            item.state = FieldCardState::Active;
+                            item.state = FieldState::Active;
                         }
                         item.battle = None;
                     }

--- a/kodecks/src/env/phase.rs
+++ b/kodecks/src/env/phase.rs
@@ -6,7 +6,7 @@ use crate::{
     config::DebugFlags,
     error::Error,
     event::{CardEvent, EventReason},
-    field::{FieldBattleState, FieldCardState},
+    field::{FieldBattleState, FieldState},
     filter_vec,
     opcode::{Opcode, OpcodeList},
     phase::Phase,
@@ -297,9 +297,9 @@ impl Environment {
                             card: attacker.id(),
                             state: Some(FieldBattleState::Attacked),
                         },
-                        Opcode::SetFieldCardState {
+                        Opcode::SetFieldState {
                             card: attacker.id(),
-                            state: FieldCardState::Exhausted,
+                            state: FieldState::Exhausted,
                         },
                     ]));
 

--- a/kodecks/src/env/phase.rs
+++ b/kodecks/src/env/phase.rs
@@ -297,11 +297,18 @@ impl Environment {
                             card: attacker.id(),
                             state: Some(FieldBattleState::Attacked),
                         },
-                        Opcode::SetFieldState {
-                            card: attacker.id(),
-                            state: FieldState::Exhausted,
-                        },
                     ]));
+
+                    if let Ok(log) = (ActionCommand::SetFieldState {
+                        source: attacker.id(),
+                        target: attacker.id(),
+                        state: FieldState::Exhausted,
+                        reason: EventReason::Battle,
+                    })
+                    .into_opcodes(self)
+                    {
+                        logs.extend(log);
+                    }
 
                     if blocker.is_none() && attacker_power > 0 {
                         logs.push(OpcodeList::new(vec![Opcode::InflictDamage {

--- a/kodecks/src/field.rs
+++ b/kodecks/src/field.rs
@@ -170,8 +170,9 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Display, Serialize, Deserialize)]
 pub enum FieldState {
+    #[default]
     Active,
     Exhausted,
 }

--- a/kodecks/src/field.rs
+++ b/kodecks/src/field.rs
@@ -16,7 +16,7 @@ pub struct Field {
 impl Field {
     pub fn active_cards(&self) -> impl Iterator<Item = &Card> {
         self.cards.iter().filter_map(|field_card| {
-            if field_card.state == FieldCardState::Active {
+            if field_card.state == FieldState::Active {
                 Some(&field_card.card)
             } else {
                 None
@@ -45,7 +45,7 @@ impl Field {
             })
     }
 
-    pub fn set_card_state(&mut self, id: ObjectId, state: FieldCardState) {
+    pub fn set_card_state(&mut self, id: ObjectId, state: FieldState) {
         if let Some(field_card) = self
             .cards
             .iter_mut()
@@ -96,7 +96,7 @@ impl CardZone for Field {
     fn push(&mut self, card: Card) {
         self.cards.push(FieldItem {
             card,
-            state: FieldCardState::Active,
+            state: FieldState::Active,
             battle: None,
         });
     }
@@ -135,7 +135,7 @@ impl CardSequence for Field {
     fn add_top(&mut self, card: Card) {
         self.cards.push(FieldItem {
             card,
-            state: FieldCardState::Active,
+            state: FieldState::Active,
             battle: None,
         });
     }
@@ -144,7 +144,7 @@ impl CardSequence for Field {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FieldItem<T: CardId> {
     pub card: T,
-    pub state: FieldCardState,
+    pub state: FieldState,
     pub battle: Option<FieldBattleState>,
 }
 
@@ -164,14 +164,14 @@ where
     fn score(&self) -> i32 {
         self.card.score()
             + match self.state {
-                FieldCardState::Active => 1,
-                FieldCardState::Exhausted => 0,
+                FieldState::Active => 1,
+                FieldState::Exhausted => 0,
             }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, Serialize, Deserialize)]
-pub enum FieldCardState {
+pub enum FieldState {
     Active,
     Exhausted,
 }

--- a/kodecks/src/opcode.rs
+++ b/kodecks/src/opcode.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::{
     color::Color,
     event::CardEvent,
-    field::{FieldBattleState, FieldCardState},
+    field::{FieldBattleState, FieldState},
     id::ObjectId,
     phase::Phase,
     player::{PlayerId, PlayerZone},
@@ -59,9 +59,9 @@ pub enum Opcode {
         target: ObjectId,
         event: CardEvent,
     },
-    SetFieldCardState {
+    SetFieldState {
         card: ObjectId,
-        state: FieldCardState,
+        state: FieldState,
     },
     Attack {
         attacker: ObjectId,

--- a/kodecks/src/player.rs
+++ b/kodecks/src/player.rs
@@ -4,7 +4,7 @@ use crate::{
     config::DebugFlags,
     deck::{Deck, DeckList},
     env::GameState,
-    field::{Field, FieldCardState, FieldItem},
+    field::{Field, FieldItem, FieldState},
     graveyard::Graveyard,
     hand::{Hand, HandItem},
     id::ObjectId,
@@ -425,7 +425,7 @@ impl CardZone for Vec<FieldItem<CardSnapshot>> {
     fn push(&mut self, card: CardSnapshot) {
         self.push(FieldItem {
             card,
-            state: FieldCardState::Active,
+            state: FieldState::Active,
             battle: None,
         });
     }


### PR DESCRIPTION
This pull request includes several changes related to the field state of cards. The `FieldCardState` enum has been renamed to `FieldState` for better clarity. Additionally, a new action command called `SetFieldState` has been added, which allows setting the state of a card on the field. 