### PR TITLE
Add TimedObjectId to check if the target card has been moved upon effect resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,6 +3059,7 @@ dependencies = [
  "rand",
  "regex-lite",
  "serde",
+ "serde_tuple",
  "strum",
  "thiserror",
  "tinystr",

--- a/kodecks-catalog/src/cards/flash_bang_jellyfish.rs
+++ b/kodecks-catalog/src/cards/flash_bang_jellyfish.rs
@@ -26,7 +26,7 @@ impl Effect for CardDef {
                     .flat_map(|p| p.field.iter())
                     .map(|card| ActionCommand::SetFieldState {
                         source: ctx.source().id(),
-                        target: card.id(),
+                        target: card.timed_id(),
                         state: kodecks::field::FieldState::Exhausted,
                         reason: EventReason::Effect,
                     });

--- a/kodecks-catalog/src/cards/mire_alligator.rs
+++ b/kodecks-catalog/src/cards/mire_alligator.rs
@@ -30,9 +30,10 @@ impl Effect for CardDef {
                     return Ok(EffectReport::default());
                 }
                 if let Some(Action::SelectCard { card }) = action {
+                    let target = ctx.state().find_card(card)?;
                     let commands = vec![ActionCommand::DestroyCard {
-                        source: card,
-                        target: card,
+                        source: ctx.source().id(),
+                        target: target.timed_id(),
                         reason: EventReason::Effect,
                     }];
                     return Ok(EffectReport::default().with_commands(commands));

--- a/kodecks/Cargo.toml
+++ b/kodecks/Cargo.toml
@@ -14,6 +14,7 @@ phf = "0.11.2"
 rand = { version = "0.8.5", features = ["small_rng"] }
 regex-lite = "0.1.6"
 serde = { version = "1.0.208", features = ["derive"] }
+serde_tuple = "0.5.0"
 strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "1.0.63"
 tinystr = { version = "0.7.6", features = ["serde"] }

--- a/kodecks/src/card.rs
+++ b/kodecks/src/card.rs
@@ -5,7 +5,7 @@ use crate::{
     deck::DeckItem,
     effect::{Effect, NoEffect},
     event::EventFilter,
-    id::{CardId, ObjectId, ObjectIdCounter},
+    id::{CardId, ObjectId, ObjectIdCounter, TimedObjectId},
     linear::Linear,
     player::{PlayerId, PlayerZone},
     score::Score,
@@ -174,6 +174,13 @@ impl CardId for Card {
     fn id(&self) -> ObjectId {
         self.id
     }
+
+    fn timed_id(&self) -> TimedObjectId {
+        TimedObjectId {
+            id: self.id,
+            timestamp: self.timestamp,
+        }
+    }
 }
 
 impl Score for Card {
@@ -201,6 +208,13 @@ pub struct CardSnapshot {
 impl CardId for CardSnapshot {
     fn id(&self) -> ObjectId {
         self.id
+    }
+
+    fn timed_id(&self) -> TimedObjectId {
+        TimedObjectId {
+            id: self.id,
+            timestamp: self.timestamp,
+        }
     }
 }
 

--- a/kodecks/src/env/phase.rs
+++ b/kodecks/src/env/phase.rs
@@ -8,6 +8,7 @@ use crate::{
     event::{CardEvent, EventReason},
     field::{FieldBattleState, FieldState},
     filter_vec,
+    id::CardId,
     opcode::{Opcode, OpcodeList},
     phase::Phase,
     player::PlayerZone,
@@ -301,7 +302,7 @@ impl Environment {
 
                     if let Ok(log) = (ActionCommand::SetFieldState {
                         source: attacker.id(),
-                        target: attacker.id(),
+                        target: attacker.timed_id(),
                         state: FieldState::Exhausted,
                         reason: EventReason::Battle,
                     })
@@ -344,7 +345,7 @@ impl Environment {
                         {
                             if let Ok(log) = (ActionCommand::DestroyCard {
                                 source: blocker.id(),
-                                target: attacker.id(),
+                                target: attacker.timed_id(),
                                 reason: EventReason::Battle,
                             })
                             .into_opcodes(self)
@@ -362,7 +363,7 @@ impl Environment {
                         {
                             if let Ok(log) = (ActionCommand::DestroyCard {
                                 source: attacker.id(),
-                                target: blocker.id(),
+                                target: blocker.timed_id(),
                                 reason: EventReason::Battle,
                             })
                             .into_opcodes(self)

--- a/kodecks/src/error.rs
+++ b/kodecks/src/error.rs
@@ -1,4 +1,7 @@
-use crate::{color::Color, id::ObjectId};
+use crate::{
+    color::Color,
+    id::{ObjectId, TimedObjectId},
+};
 use thiserror::Error;
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -13,4 +16,6 @@ pub enum Error {
     KeyNotFound { key: String },
     #[error("Invalid value type")]
     InvalidValueType,
+    #[error("Target lost: {target}")]
+    TargetLost { target: TimedObjectId },
 }

--- a/kodecks/src/field.rs
+++ b/kodecks/src/field.rs
@@ -1,6 +1,6 @@
 use crate::{
     card::Card,
-    id::{CardId, ObjectId},
+    id::{CardId, ObjectId, TimedObjectId},
     score::Score,
     sequence::CardSequence,
     zone::CardZone,
@@ -154,6 +154,10 @@ where
 {
     fn id(&self) -> ObjectId {
         self.card.id()
+    }
+
+    fn timed_id(&self) -> TimedObjectId {
+        self.card.timed_id()
     }
 }
 

--- a/kodecks/src/hand.rs
+++ b/kodecks/src/hand.rs
@@ -1,7 +1,7 @@
 use crate::{
     card::Card,
     error::Error,
-    id::{CardId, ObjectId},
+    id::{CardId, ObjectId, TimedObjectId},
     sequence::CardSequence,
     zone::CardZone,
 };
@@ -102,5 +102,9 @@ where
 {
     fn id(&self) -> ObjectId {
         self.card.id()
+    }
+
+    fn timed_id(&self) -> TimedObjectId {
+        self.card.timed_id()
     }
 }

--- a/kodecks/src/id.rs
+++ b/kodecks/src/id.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 const MAX_RESERVED_ID: u64 = 100;
 
@@ -39,6 +40,19 @@ impl ObjectIdCounter {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize_tuple, Deserialize_tuple, Hash)]
+pub struct TimedObjectId {
+    pub id: ObjectId,
+    pub timestamp: u64,
+}
+
+impl fmt::Display for TimedObjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.id, self.timestamp)
+    }
+}
+
 pub trait CardId {
     fn id(&self) -> ObjectId;
+    fn timed_id(&self) -> TimedObjectId;
 }


### PR DESCRIPTION
This pull request adds a new struct called `TimedObjectId` which includes both the `ObjectId` and a `timestamp`. This struct is used to check if the target card has been moved upon effect resolution.