### PR TITLE
ActionCommand::ShuffleCardIntoDeck

### DIFF
--- a/kodecks-bevy/src/scene/game/board.rs
+++ b/kodecks-bevy/src/scene/game/board.rs
@@ -256,8 +256,8 @@ impl Board {
                 }
             } else if zone.zone == Zone::Deck {
                 let transform = Transform::from_rotation(Quat::from_rotation_z(PI))
-                    .with_translation(Vec3::new(5.0, 2.0, 2.5))
-                    .with_scale(Vec3::splat(0.8));
+                    .with_translation(Vec3::new(5.0, 0.0, 3.0))
+                    .with_scale(Vec3::splat(0.0));
                 return Some(transform);
             } else if zone.zone == Zone::Graveyard {
                 let transform = Transform::from_xyz(3.9, -0.5, 3.0).with_scale(Vec3::splat(0.8));
@@ -301,7 +301,8 @@ impl Board {
         } else if zone.zone == Zone::Deck {
             let mut transform =
                 Transform::from_rotation(Quat::from_rotation_z(std::f32::consts::PI))
-                    .with_translation(Vec3::new(6.0, 0.2, -3.0));
+                    .with_translation(Vec3::new(5.0, 0.0, -1.5))
+                    .with_scale(Vec3::splat(0.0));
             transform.rotate_local_y(std::f32::consts::PI);
             return Some(transform);
         } else if zone.zone == Zone::Graveyard {

--- a/kodecks-bevy/src/scene/game/main/animation.rs
+++ b/kodecks-bevy/src/scene/game/main/animation.rs
@@ -8,6 +8,7 @@ use bevy::ecs::system::SystemParam;
 use bevy::ecs::world::Command;
 use bevy::prelude::*;
 use bevy::utils::hashbrown::HashSet;
+use kodecks::player::PlayerZone;
 use kodecks::target::Target;
 use kodecks::zone::Zone;
 use std::f32::consts::PI;
@@ -240,7 +241,13 @@ fn start_move_animation(
                 let (zone, log) = if let Ok(zone) = res.env.find_zone(card.id) {
                     (zone, moved.contains(&card.id))
                 } else {
-                    return;
+                    (
+                        PlayerZone {
+                            player: card.owner,
+                            zone: Zone::Deck,
+                        },
+                        false,
+                    )
                 };
 
                 let mut animation = AnimationClip::default();

--- a/kodecks/src/env/event.rs
+++ b/kodecks/src/env/event.rs
@@ -70,6 +70,19 @@ impl Environment {
                     trigger,
                 ],)),])
             }
+            CardEvent::ReturnedToDeck => {
+                let from = *target.zone();
+                let to = PlayerZone::new(target.owner(), Zone::Deck);
+                Ok(filter_vec![Some(OpcodeList::new(filter_vec![
+                    Some(Opcode::MoveCard {
+                        card: target.id(),
+                        from,
+                        to,
+                        reason: MoveReason::Move,
+                    }),
+                    trigger,
+                ],)),])
+            }
             _ => Ok(vec![OpcodeList::new(filter_vec![trigger,])]),
         }
     }

--- a/kodecks/src/env/opcode.rs
+++ b/kodecks/src/env/opcode.rs
@@ -176,6 +176,11 @@ impl Environment {
                 }
                 Ok(vec![])
             }
+            Opcode::ShuffleDeck { player } => {
+                let player = self.state.players.get_mut(*player);
+                player.deck.shuffle(&mut self.obj_counter, &mut self.rng);
+                Ok(vec![LogAction::DeckShuffled { player: player.id }])
+            }
             Opcode::TriggerEvent {
                 source,
                 target,

--- a/kodecks/src/event.rs
+++ b/kodecks/src/event.rs
@@ -13,6 +13,7 @@ pub enum CardEvent {
     ReturnedToHand {
         reason: EventReason,
     },
+    ReturnedToDeck,
     DealtDamage {
         player: PlayerId,
         amount: u32,
@@ -30,6 +31,7 @@ impl CardEvent {
             CardEvent::Casted => EventFilter::CASTED,
             CardEvent::Destroyed { .. } => EventFilter::DESTROYED,
             CardEvent::ReturnedToHand { .. } => EventFilter::RETURNED_TO_HAND,
+            CardEvent::ReturnedToDeck => EventFilter::RETURNED_TO_DECK,
             CardEvent::DealtDamage { .. } => EventFilter::DEALT_DAMAGE,
             CardEvent::Attacking => EventFilter::ATTACKING,
             CardEvent::Blocking => EventFilter::BLOCKING,
@@ -45,11 +47,12 @@ bitflags! {
         const CASTED = 1 << 0;
         const DESTROYED = 1 << 1;
         const RETURNED_TO_HAND = 1 << 2;
-        const DEALT_DAMAGE = 1 << 3;
-        const ATTACKING = 1 << 4;
-        const BLOCKING = 1 << 5;
-        const ATTACKED = 1 << 6;
-        const ANY_CASTED = 1 << 7;
+        const RETURNED_TO_DECK = 1 << 3;
+        const DEALT_DAMAGE = 1 << 4;
+        const ATTACKING = 1 << 5;
+        const BLOCKING = 1 << 6;
+        const ATTACKED = 1 << 7;
+        const ANY_CASTED = 1 << 8;
     }
 }
 

--- a/kodecks/src/game.rs
+++ b/kodecks/src/game.rs
@@ -1,17 +1,12 @@
 use crate::{
     action::{Action, PlayerAvailableActions},
-    card::{Card, Catalog},
+    card::Catalog,
     env::{Environment, GameCondition},
-    id::ObjectIdCounter,
     log::LogAction,
-    player::{PlayerId, PlayerState},
+    player::PlayerId,
     profile::GameProfile,
     scenario::Scenario,
-    sequence::CardSequence,
 };
-use rand::rngs::SmallRng;
-use rand::seq::SliceRandom;
-use rand::SeedableRng;
 use std::sync::Arc;
 
 pub struct Game {
@@ -21,36 +16,8 @@ pub struct Game {
 
 impl Game {
     pub fn new(profile: GameProfile, catalog: &'static Catalog) -> Game {
-        let mut rng: SmallRng = profile
-            .config
-            .rng_seed
-            .map(SmallRng::seed_from_u64)
-            .unwrap_or_else(SmallRng::from_entropy);
-
-        let mut counter = ObjectIdCounter::default();
-        let mut players = profile
-            .players
-            .into_iter()
-            .map(|player| {
-                let mut state = PlayerState::new(player.id);
-                for item in &player.deck.cards {
-                    let archetype = &catalog[item.archetype_id];
-                    let card = Card::new(&mut counter, item, archetype, player.id);
-                    state.deck.add_top(card);
-                }
-                if !profile.config.no_deck_shuffle {
-                    state.deck.shuffle(&mut counter, &mut rng);
-                }
-                state
-            })
-            .collect::<Vec<_>>();
-
-        if !profile.config.no_player_shuffle {
-            players.shuffle(&mut rng);
-        }
-
         Game {
-            env: Arc::new(Environment::new(profile.config, players)),
+            env: Arc::new(Environment::new(profile, catalog)),
             scenario: None,
         }
     }

--- a/kodecks/src/log.rs
+++ b/kodecks/src/log.rs
@@ -50,6 +50,8 @@ pub enum LogAction {
         to: PlayerZone,
         reason: MoveReason,
     },
+    #[strum(to_string = "Deck shuffled for {player}")]
+    DeckShuffled { player: PlayerId },
     #[strum(to_string = "Effect {id} triggered by {source}")]
     EffectTriggered { source: ObjectId, id: EffectId },
     #[strum(to_string = "Card {targets:?} targeted by {source}")]

--- a/kodecks/src/opcode.rs
+++ b/kodecks/src/opcode.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use crate::{
     color::Color,
     event::CardEvent,
@@ -10,6 +8,7 @@ use crate::{
     target::Target,
     zone::MoveReason,
 };
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub enum Opcode {
@@ -53,6 +52,9 @@ pub enum Opcode {
         from: PlayerZone,
         to: PlayerZone,
         reason: MoveReason,
+    },
+    ShuffleDeck {
+        player: PlayerId,
     },
     TriggerEvent {
         source: ObjectId,


### PR DESCRIPTION
This pull request adds a new opcode called `ShuffleDeck` and a new action command called `ShuffleCardIntoDeck`. The `ShuffleDeck` opcode shuffles the deck of a specific player, while the `ShuffleCardIntoDeck` action command shuffles a specific card into its owner's deck.