### PR TITLE
Communicate server with serializable channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,15 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,17 +225,6 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
@@ -256,19 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compat"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bab94bde396a3f7b4962e396fdad640e241ed797d4d8d77fc8c237d14c58fc0"
-dependencies = [
- "futures-core",
- "futures-io",
- "once_cell",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "async-executor"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,8 +243,8 @@ checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.0.2",
- "futures-lite 2.3.0",
+ "fastrand",
+ "futures-lite",
  "slab",
 ]
 
@@ -287,72 +254,9 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock",
  "blocking",
- "futures-lite 2.3.0",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io 2.3.3",
- "async-lock 3.3.0",
- "blocking",
- "futures-lite 2.3.0",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.27",
- "slab",
- "socket2",
- "waker-fn",
-]
-
-[[package]]
-name = "async-io"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
-dependencies = [
- "async-lock 3.3.0",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.3.0",
- "parking",
- "polling 3.7.0",
- "rustix 0.38.34",
- "slab",
- "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
+ "futures-lite",
 ]
 
 [[package]]
@@ -364,32 +268,6 @@ dependencies = [
  "event-listener 4.0.3",
  "event-listener-strategy 0.4.0",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 1.13.0",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -409,21 +287,6 @@ name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
-
-[[package]]
-name = "backtrace"
-version = "0.3.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base64"
@@ -514,7 +377,7 @@ checksum = "6533d17f13b44ea4fb5177f83b0900269ed13c0fd45772ccffd19a69980647ec"
 dependencies = [
  "async-broadcast",
  "async-fs",
- "async-lock 3.3.0",
+ "async-lock",
  "bevy_app",
  "bevy_asset_macros",
  "bevy_ecs",
@@ -526,7 +389,7 @@ dependencies = [
  "crossbeam-channel",
  "downcast-rs",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite",
  "js-sys",
  "parking_lot",
  "ron",
@@ -571,18 +434,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
-]
-
-[[package]]
-name = "bevy_async_task"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3570cf1389d868d4c0f154fd161d9f338f1bc837f2add3d458552cf895171256"
-dependencies = [
- "async-compat",
- "async-std",
- "bevy",
- "tokio",
 ]
 
 [[package]]
@@ -1178,7 +1029,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f570f36154296ae5377587d5ef19e1feb4c5734923785c571f55a9fff091701"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "bevy_app",
  "bevy_asset",
  "bevy_color",
@@ -1202,7 +1053,7 @@ dependencies = [
  "codespan-reporting",
  "downcast-rs",
  "encase",
- "futures-lite 2.3.0",
+ "futures-lite",
  "hexasphere",
  "image",
  "js-sys",
@@ -1311,10 +1162,10 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84f5414c3f49c96e02ceccf5fa12fb6cfbf8b271d2a820902d6f622e9c2fa681"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "async-executor",
  "concurrent-queue",
- "futures-lite 2.3.0",
+ "futures-lite",
  "wasm-bindgen-futures",
 ]
 
@@ -1553,11 +1404,11 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
 dependencies = [
- "async-channel 2.3.1",
- "async-lock 3.3.0",
+ "async-channel",
+ "async-lock",
  "async-task",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite",
  "piper",
 ]
 
@@ -1613,8 +1464,8 @@ checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
 dependencies = [
  "bitflags 2.6.0",
  "log",
- "polling 3.7.0",
- "rustix 0.38.34",
+ "polling",
+ "rustix",
  "slab",
  "thiserror",
 ]
@@ -2157,15 +2008,6 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
@@ -2342,26 +2184,11 @@ checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.0.2",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -2467,12 +2294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
-
-[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,18 +2334,6 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2925,15 +2734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "intl-memoizer"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,17 +2760,6 @@ checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
 dependencies = [
  "core-foundation-sys",
  "mach2",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3071,10 +2860,9 @@ dependencies = [
 name = "kodecks-bevy"
 version = "0.1.0"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "bevy",
  "bevy_asset_loader",
- "bevy_async_task",
  "bevy_mod_picking",
  "dashmap",
  "fluent-bundle",
@@ -3086,6 +2874,7 @@ dependencies = [
  "kodecks",
  "kodecks-bot",
  "kodecks-catalog",
+ "kodecks-server",
  "rand",
  "serde",
  "serde_default",
@@ -3121,21 +2910,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kodecks-server"
+version = "0.1.0"
+dependencies = [
+ "kodecks",
+ "kodecks-bot",
+ "kodecks-catalog",
+ "serde",
+ "tracing",
+]
+
+[[package]]
 name = "ktx2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87d65e08a9ec02e409d27a0139eaa6b9756b4d81fe7cde71f6941a83730ce838"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -3210,12 +3001,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
@@ -3247,9 +3032,6 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "mach2"
@@ -3775,15 +3557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "oboe"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,7 +3758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "464db0c665917b13ebb5d453ccdec4add5658ee1adc7affc7677615356a8afaf"
 dependencies = [
  "atomic-waker",
- "fastrand 2.0.2",
+ "fastrand",
  "futures-io",
 ]
 
@@ -4010,22 +3783,6 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
@@ -4034,7 +3791,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.34",
+ "rustix",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4285,30 +4042,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "rustix"
@@ -4319,7 +4056,7 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -4504,16 +4241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -4707,16 +4434,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
-dependencies = [
- "backtrace",
- "pin-project-lite",
-]
 
 [[package]]
 name = "toml_datetime"
@@ -4967,12 +4684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4983,12 +4694,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -5321,15 +5026,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5545,7 +5241,7 @@ dependencies = [
  "pin-project",
  "raw-window-handle",
  "redox_syscall 0.4.1",
- "rustix 0.38.34",
+ "rustix",
  "smol_str",
  "tracing",
  "unicode-segmentation",
@@ -5611,7 +5307,7 @@ dependencies = [
  "libc",
  "libloading 0.8.3",
  "once_cell",
- "rustix 0.38.34",
+ "rustix",
  "x11rb-protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "2"
-members = ["kodecks", "kodecks-bevy", "kodecks-bot", "kodecks-catalog"]
+members = [
+    "kodecks",
+    "kodecks-bevy",
+    "kodecks-bot",
+    "kodecks-catalog",
+    "kodecks-server",
+]
 
 [profile.dev]
 debug = 0

--- a/kodecks-bevy/Cargo.toml
+++ b/kodecks-bevy/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 async-channel = "2.3.1"
 bevy = "0.14.1"
 bevy_asset_loader = { version = "0.21.0", features = ["3d"] }
-bevy_async_task = "0.2.0"
 bevy_mod_picking = { version = "0.20.1", features = [
     "backend_raycast",
     "backend_bevy_ui",
@@ -22,6 +21,7 @@ image = { version = "0.25.2", default-features = false, features = ["png"] }
 kodecks = { path = "../kodecks" }
 kodecks-bot = { path = "../kodecks-bot" }
 kodecks-catalog = { path = "../kodecks-catalog" }
+kodecks-server = { path = "../kodecks-server" }
 rand = "0.8.5"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_default = "0.2.0"

--- a/kodecks-bevy/src/scene/game/loading/mod.rs
+++ b/kodecks-bevy/src/scene/game/loading/mod.rs
@@ -1,4 +1,7 @@
-use super::{board, event, server};
+use super::{
+    board, event,
+    server::{self, Server},
+};
 use crate::scene::GlobalState;
 use bevy::prelude::*;
 use kodecks_catalog::profile;
@@ -12,7 +15,6 @@ impl Plugin for GameLoadingPlugin {
             .add_plugins(event::EventPlugin)
             .add_systems(OnEnter(GlobalState::GameInit), init_loading_screen)
             .add_systems(OnExit(GlobalState::GameLoading), cleanup_loading_screen)
-            .add_systems(OnEnter(GlobalState::GameCleanup), cleanup)
             .add_systems(
                 Update,
                 (finish_load.run_if(resource_exists::<board::Environment>))
@@ -43,16 +45,12 @@ fn finish_load(
     }
 }
 
-fn cleanup(mut commands: Commands) {
-    commands.remove_resource::<server::Server>();
-}
-
 fn wait_env(mut next_state: ResMut<NextState<GlobalState>>) {
     next_state.set(GlobalState::GameLoading);
 }
 
-fn init_loading_screen(mut commands: Commands) {
-    commands.insert_resource(server::Server::new(profile::default_profile()));
+fn init_loading_screen(mut commands: Commands, mut conn: ResMut<Server>) {
+    conn.create_session(profile::default_profile());
 
     commands.spawn((
         NodeBundle {

--- a/kodecks-bevy/src/scene/game/server.rs
+++ b/kodecks-bevy/src/scene/game/server.rs
@@ -1,60 +1,73 @@
 use crate::scene::GlobalState;
 use bevy::{ecs::world::Command, prelude::*};
-use bevy_async_task::{AsyncTaskRunner, AsyncTaskStatus};
-use futures::channel::mpsc::{Receiver, Sender};
-use kodecks::{
-    action::{Action, PlayerAvailableActions},
-    env::LocalEnvironment,
-    game::Game,
-    log::LogAction,
-    player::PlayerId,
-    profile::GameProfile,
-};
-use kodecks_bot::{Bot, DefaultBot};
-use kodecks_catalog::CATALOG;
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+use futures::channel::mpsc::Receiver;
+use kodecks::{action::Action, game::LocalGameState, player::PlayerId, profile::GameProfile};
+use kodecks_server::message::{self, Input};
+use std::sync::Mutex;
 
 pub struct ServerPlugin;
 
 impl Plugin for ServerPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<ServerEvent>()
-            .add_systems(OnEnter(GlobalState::GameInit), init)
+            .init_resource::<Server>()
             .add_systems(OnEnter(GlobalState::GameCleanup), cleanup)
-            .add_systems(Update, recv_events.run_if(resource_exists::<ServerChannel>))
-            .add_systems(
-                Update,
-                run_server
-                    .run_if(resource_exists::<Server>.and_then(resource_exists::<ServerChannel>)),
-            );
+            .add_systems(Update, recv_events);
     }
 }
 
-fn init(mut commands: Commands) {
-    commands.insert_resource(ServerChannel::default());
-}
-
 fn cleanup(mut commands: Commands) {
-    commands.remove_resource::<ServerChannel>();
+    commands.remove_resource::<Session>();
 }
 
 #[derive(Resource)]
 pub struct Server {
-    game: Game,
-    available_actions: Option<PlayerAvailableActions>,
-    user_player: PlayerId,
-    player_in_action: PlayerId,
+    server: kodecks_server::Server,
+    event_recv: Receiver<kodecks_server::message::Output>,
+}
+
+impl Default for Server {
+    fn default() -> Self {
+        let (event_send, event_recv) = futures::channel::mpsc::channel(256);
+        let event_send = Mutex::new(event_send);
+        let server = kodecks_server::Server::new(move |event| {
+            event_send.lock().unwrap().try_send(event).unwrap();
+        });
+        Self { server, event_recv }
+    }
 }
 
 impl Server {
-    pub fn new(profile: GameProfile) -> Self {
-        let game = Game::new(profile, &CATALOG);
-        let player_in_action = game.env().state.players.player_in_turn().id;
-        Self {
-            game,
-            available_actions: None,
-            user_player: PlayerId::new("player1"),
-            player_in_action,
+    pub fn create_session(&mut self, profile: GameProfile) {
+        self.server
+            .handle_input(Input::Command(message::Command::CreateSession { profile }));
+    }
+}
+
+#[derive(Resource)]
+struct Session {
+    id: u32,
+    player: PlayerId,
+}
+
+fn recv_events(
+    mut commands: Commands,
+    mut server: ResMut<Server>,
+    mut events: EventWriter<ServerEvent>,
+) {
+    while let Ok(Some(event)) = server.event_recv.try_next() {
+        match event {
+            message::Output::SessionEvent(event) => match event.event {
+                message::SessionEventKind::Created => {
+                    commands.insert_resource(Session {
+                        id: event.session,
+                        player: event.player,
+                    });
+                }
+                message::SessionEventKind::GameUpdated { state } => {
+                    events.send(ServerEvent(state));
+                }
+            },
         }
     }
 }
@@ -63,105 +76,20 @@ pub struct SendCommand(pub Action);
 
 impl Command for SendCommand {
     fn apply(self, world: &mut World) {
-        if let Some(mut channel) = world.get_resource_mut::<ServerChannel>() {
-            let _ = channel.cmd_send.try_send(self.0);
-        }
-    }
-}
-
-#[derive(Event, Clone, Serialize_tuple, Deserialize_tuple)]
-pub struct ServerEvent {
-    pub env: LocalEnvironment,
-    pub logs: Vec<LogAction>,
-    pub available_actions: Option<PlayerAvailableActions>,
-}
-
-#[derive(Resource)]
-struct ServerChannel {
-    cmd_send: Sender<Action>,
-    cmd_recv: Receiver<Action>,
-    event_send: Sender<ServerEvent>,
-    event_recv: Receiver<ServerEvent>,
-}
-
-impl Default for ServerChannel {
-    fn default() -> Self {
-        let (cmd_send, cmd_recv) = futures::channel::mpsc::channel(256);
-        let (event_send, event_recv) = futures::channel::mpsc::channel(256);
-        Self {
-            cmd_send,
-            cmd_recv,
-            event_send,
-            event_recv,
-        }
-    }
-}
-
-fn recv_events(mut channel: ResMut<ServerChannel>, mut events: EventWriter<ServerEvent>) {
-    while let Ok(Some(event)) = channel.event_recv.try_next() {
-        events.send(event);
-    }
-}
-
-fn run_server(
-    mut server: ResMut<Server>,
-    mut channel: ResMut<ServerChannel>,
-    mut runner: AsyncTaskRunner<Option<Action>>,
-) {
-    let mut action = None;
-
-    if server
-        .available_actions
-        .as_ref()
-        .map_or(false, |actions| !actions.actions.is_empty())
-    {
-        if server.player_in_action == server.user_player {
-            if let Ok(Some(player_action)) = channel.cmd_recv.try_next() {
-                action = Some(player_action);
-            } else {
-                return;
-            }
-        } else {
-            match runner.poll() {
-                AsyncTaskStatus::Finished(bot_action) => {
-                    action = bot_action;
-                }
-                AsyncTaskStatus::Idle => {}
-                _ => {
-                    return;
-                }
+        if let Some(session) = world.get_resource::<Session>() {
+            let id = session.id;
+            let player = session.player;
+            if let Some(mut conn) = world.get_resource_mut::<Server>() {
+                conn.server
+                    .handle_input(Input::SessionCommand(message::SessionCommand {
+                        session: id,
+                        player,
+                        kind: message::SessionCommandKind::NextAction { action: self.0 },
+                    }));
             }
         }
     }
-
-    let player = server.player_in_action;
-    let report = server.game.tick(player, action);
-    server
-        .available_actions
-        .clone_from(&report.available_actions);
-
-    if let Some(available_actions) = &report.available_actions {
-        server.player_in_action = available_actions.player;
-    }
-
-    if let Some(actions) = &report.available_actions {
-        if actions.player != server.user_player && !actions.actions.is_empty() {
-            let env = server.game.env().clone();
-            let report = report.clone();
-            if let Some(available_actions) = report.available_actions {
-                runner.start(async move {
-                    let mut bot = DefaultBot::builder().build();
-                    bot.compute_best_action(env, &available_actions)
-                });
-            }
-        }
-    }
-
-    let _ = channel.event_send.try_send(ServerEvent {
-        env: server.game.env().local(server.user_player),
-        logs: report.logs,
-        available_actions: report
-            .available_actions
-            .filter(|actions| actions.player == server.user_player),
-    });
 }
+
+#[derive(Event, Clone, Deref)]
+pub struct ServerEvent(LocalGameState);

--- a/kodecks-catalog/src/profile.rs
+++ b/kodecks-catalog/src/profile.rs
@@ -3,7 +3,7 @@ use kodecks::{
     config::{DebugFlags, GameConfig},
     deck::DeckList,
     player::{PlayerConfig, PlayerId},
-    profile::GameProfile,
+    profile::{BotConfig, GameProfile},
 };
 
 pub fn default_profile() -> GameProfile {
@@ -52,6 +52,9 @@ pub fn default_profile() -> GameProfile {
                 deck: deck_list_red,
             },
         ],
+        bots: vec![BotConfig {
+            player: PlayerId::new("player2"),
+        }],
         scenario: None,
     }
 }

--- a/kodecks-server/Cargo.toml
+++ b/kodecks-server/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kodecks-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+kodecks = { path = "../kodecks" }
+kodecks-bot = { path = "../kodecks-bot" }
+kodecks-catalog = { path = "../kodecks-catalog" }
+serde = { version = "1.0.208", features = ["derive"] }
+tracing = "0.1.40"

--- a/kodecks-server/src/lib.rs
+++ b/kodecks-server/src/lib.rs
@@ -1,0 +1,55 @@
+use kodecks::profile::GameProfile;
+use message::{Command, Input};
+use session::Session;
+use std::{collections::HashMap, sync::Arc};
+
+pub mod message;
+pub mod session;
+
+pub type ServerCallback = dyn Fn(message::Output) + Send + Sync + 'static;
+
+pub struct Server {
+    session_counter: u32,
+    sessions: HashMap<u32, Session>,
+    callback: Arc<Box<ServerCallback>>,
+}
+
+impl Server {
+    pub fn new<F>(callback: F) -> Self
+    where
+        F: Fn(message::Output) + Send + Sync + 'static,
+    {
+        Self {
+            session_counter: 0,
+            sessions: HashMap::new(),
+            callback: Arc::new(Box::new(callback)),
+        }
+    }
+
+    pub fn handle_input(&mut self, input: message::Input) {
+        match input {
+            Input::Command(command) => match command {
+                Command::CreateSession { profile } => {
+                    self.create_session(profile);
+                }
+            },
+            message::Input::SessionCommand(session_command) => {
+                let id = session_command.session;
+                if let Some(session) = self.sessions.get_mut(&id) {
+                    session.process_command(session_command);
+                    if session.is_ended() {
+                        self.sessions.remove(&id);
+                    }
+                }
+            }
+        }
+    }
+
+    fn create_session(&mut self, profile: GameProfile) {
+        let session_id = self.session_counter;
+        self.session_counter += 1;
+
+        let session = Session::new(session_id, profile, self.callback.clone());
+        self.sessions.insert(session_id, session);
+    }
+}

--- a/kodecks-server/src/message.rs
+++ b/kodecks-server/src/message.rs
@@ -1,0 +1,50 @@
+use kodecks::{action::Action, game::LocalGameState, player::PlayerId, profile::GameProfile};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Input {
+    Command(Command),
+    SessionCommand(SessionCommand),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+pub enum Command {
+    CreateSession { profile: GameProfile },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SessionCommand {
+    pub session: u32,
+    pub player: PlayerId,
+    #[serde(flatten)]
+    pub kind: SessionCommandKind,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+pub enum SessionCommandKind {
+    NextAction { action: Action },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Output {
+    SessionEvent(SessionEvent),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SessionEvent {
+    pub session: u32,
+    pub player: PlayerId,
+    #[serde(flatten)]
+    pub event: SessionEventKind,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum SessionEventKind {
+    Created,
+    GameUpdated { state: LocalGameState },
+}

--- a/kodecks-server/src/session.rs
+++ b/kodecks-server/src/session.rs
@@ -1,0 +1,122 @@
+use crate::{
+    message::{Output, SessionCommand, SessionCommandKind, SessionEvent, SessionEventKind},
+    ServerCallback,
+};
+use kodecks::{
+    action::{Action, PlayerAvailableActions},
+    game::{Game, LocalGameState},
+    player::PlayerId,
+    profile::{BotConfig, GameProfile},
+};
+use kodecks_bot::{Bot, DefaultBot};
+use kodecks_catalog::CATALOG;
+use std::{collections::HashMap, sync::Arc};
+
+pub struct Session {
+    id: u32,
+    game: Game,
+    bots: Vec<BotConfig>,
+    next_actions: HashMap<PlayerId, Action>,
+    available_actions: Option<PlayerAvailableActions>,
+    player_in_action: PlayerId,
+    default_bot: DefaultBot,
+    callback: Arc<Box<ServerCallback>>,
+}
+
+impl Session {
+    pub fn new(id: u32, profile: GameProfile, callback: Arc<Box<ServerCallback>>) -> Self {
+        let bots = profile.bots.clone();
+        let game = Game::new(profile, &CATALOG);
+        let player_in_action = game.env().state.players.player_in_turn().id;
+
+        let mut session = Self {
+            id,
+            game,
+            bots,
+            next_actions: HashMap::new(),
+            available_actions: None,
+            player_in_action,
+            default_bot: DefaultBot::builder().build(),
+            callback: callback.clone(),
+        };
+
+        for player in session.players() {
+            let is_bot = session.bots.iter().any(|bot| bot.player == player);
+            if !is_bot {
+                (callback)(Output::SessionEvent(SessionEvent {
+                    session: id,
+                    player,
+                    event: SessionEventKind::Created,
+                }));
+            }
+        }
+
+        session.progress();
+        session
+    }
+
+    pub fn process_command(&mut self, command: SessionCommand) {
+        match command.kind {
+            SessionCommandKind::NextAction { action } => {
+                self.next_actions.insert(command.player, action);
+            }
+        }
+        self.progress();
+    }
+
+    fn progress(&mut self) {
+        while !self.game.env().game_condition().is_ended() {
+            let mut next_action = None;
+            if let Some(available_actions) = &self.available_actions {
+                let is_bot = self
+                    .bots
+                    .iter()
+                    .any(|bot| bot.player == self.player_in_action);
+                if is_bot {
+                    let env = self.game.env().clone();
+                    next_action = self.default_bot.compute_best_action(env, available_actions);
+                } else if let Some(action) = self.next_actions.remove(&self.player_in_action) {
+                    next_action = Some(action);
+                } else {
+                    return;
+                }
+            }
+
+            let player = self.player_in_action;
+            let report = self.game.tick(player, next_action);
+            self.available_actions.clone_from(&report.available_actions);
+
+            if let Some(available_actions) = &report.available_actions {
+                self.player_in_action = available_actions.player;
+            }
+
+            for player in self.players() {
+                let is_bot = self.bots.iter().any(|bot| bot.player == player);
+                if !is_bot {
+                    let state = LocalGameState {
+                        env: self.game.env().local(player),
+                        logs: report.logs.clone(),
+                        available_actions: report
+                            .available_actions
+                            .clone()
+                            .filter(|actions| actions.player == player),
+                    };
+                    let event = SessionEvent {
+                        session: self.id,
+                        player,
+                        event: SessionEventKind::GameUpdated { state },
+                    };
+                    (self.callback)(Output::SessionEvent(event));
+                }
+            }
+        }
+    }
+
+    pub fn players(&self) -> impl Iterator<Item = PlayerId> + '_ {
+        self.game.env().state.players.iter().map(|p| p.id)
+    }
+
+    pub fn is_ended(&self) -> bool {
+        self.game.env().game_condition().is_ended()
+    }
+}

--- a/kodecks/src/profile.rs
+++ b/kodecks/src/profile.rs
@@ -1,11 +1,32 @@
-use crate::{config::GameConfig, player::PlayerConfig, scenario::Scenario};
+use crate::{
+    config::GameConfig,
+    player::{PlayerConfig, PlayerId},
+    scenario::Scenario,
+};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 #[derive(Serialize, Deserialize)]
 pub struct GameProfile {
     pub config: GameConfig,
     pub players: Vec<PlayerConfig>,
+    pub bots: Vec<BotConfig>,
 
     #[serde(skip)]
     pub scenario: Option<Box<dyn Scenario>>,
+}
+
+impl fmt::Debug for GameProfile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GameProfile")
+            .field("config", &self.config)
+            .field("players", &self.players)
+            .field("bots", &self.bots)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BotConfig {
+    pub player: PlayerId,
 }


### PR DESCRIPTION
This pull request adds server functionality to handle game sessions. It includes the following changes:

- Added a new crate `kodecks-server` to the workspace

- Created a `Server` struct to manage game sessions

- Implemented the ability to create a new session with a given game profile

- Implemented the ability to handle input commands for sessions

- Implemented the ability to process session commands and progress the game

- Added the `Session` struct to represent a game session

- Implemented the ability to process session commands and progress the game within a session

- Added the `Input`, `Output`, `Command`, `SessionCommand`, `SessionEvent`, and related structs to handle communication between the server and clients

This pull request addresses the need for a server to handle game sessions and allows for the creation and management of multiple game sessions.