### PR TITLE
Add Connection trait for abstract server communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,6 +2889,7 @@ dependencies = [
 name = "kodecks-server"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "kodecks",
  "kodecks-bot",
  "kodecks-catalog",

--- a/kodecks-bevy/src/scene/game/loading/mod.rs
+++ b/kodecks-bevy/src/scene/game/loading/mod.rs
@@ -5,6 +5,10 @@ use super::{
 use crate::scene::GlobalState;
 use bevy::prelude::*;
 use kodecks_catalog::profile;
+use kodecks_server::{
+    message::{Command, Input},
+    Connection,
+};
 
 pub struct GameLoadingPlugin;
 
@@ -50,7 +54,9 @@ fn wait_env(mut next_state: ResMut<NextState<GlobalState>>) {
 }
 
 fn init_loading_screen(mut commands: Commands, mut conn: ResMut<Server>) {
-    conn.create_session(profile::default_profile());
+    conn.send(Input::Command(Command::CreateSession {
+        profile: profile::default_profile(),
+    }));
 
     commands.spawn((
         NodeBundle {

--- a/kodecks-server/Cargo.toml
+++ b/kodecks-server/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+futures = "0.3.30"
 kodecks = { path = "../kodecks" }
 kodecks-bot = { path = "../kodecks-bot" }
 kodecks-catalog = { path = "../kodecks-catalog" }

--- a/kodecks-server/src/lib.rs
+++ b/kodecks-server/src/lib.rs
@@ -3,6 +3,7 @@ use message::{Command, Input};
 use session::Session;
 use std::{collections::HashMap, sync::Arc};
 
+pub mod local;
 pub mod message;
 pub mod session;
 
@@ -52,4 +53,9 @@ impl Server {
         let session = Session::new(session_id, profile, self.callback.clone());
         self.sessions.insert(session_id, session);
     }
+}
+
+pub trait Connection {
+    fn send(&mut self, output: message::Input);
+    fn recv(&mut self) -> Option<message::Output>;
 }

--- a/kodecks-server/src/local.rs
+++ b/kodecks-server/src/local.rs
@@ -1,0 +1,32 @@
+use crate::{
+    message::{Input, Output},
+    Connection, Server,
+};
+use futures::channel::mpsc::{self, Receiver};
+use std::sync::Mutex;
+
+pub struct LocalServer {
+    server: Server,
+    event_recv: Receiver<Output>,
+}
+
+impl Default for LocalServer {
+    fn default() -> Self {
+        let (event_send, event_recv) = mpsc::channel(256);
+        let event_send = Mutex::new(event_send);
+        let server = Server::new(move |event| {
+            event_send.lock().unwrap().try_send(event).unwrap();
+        });
+        Self { server, event_recv }
+    }
+}
+
+impl Connection for LocalServer {
+    fn send(&mut self, input: Input) {
+        self.server.handle_input(input);
+    }
+
+    fn recv(&mut self) -> Option<Output> {
+        self.event_recv.try_next().ok().flatten()
+    }
+}


### PR DESCRIPTION
This pull request adds a new trait called `Connection` that provides an abstraction for server communication. It also includes the implementation of `Connection` for the `LocalServer` struct. This allows for easier testing and decoupling of server communication logic.