### PR TITLE
Add embed_assets feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_embedded_assets"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3f3e7b41a9b01b767ba07c4ebb083b2d8d8055e57ddef7e55e502bbfc961505"
+dependencies = [
+ "bevy",
+ "cargo-emit",
+ "futures-io",
+ "futures-lite",
+ "thiserror",
+]
+
+[[package]]
 name = "bevy_encase_derive"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1547,12 @@ checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "cargo-emit"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1582e1c9e755dd6ad6b224dcffb135d199399a4568d454bd89fe515ca8425695"
 
 [[package]]
 name = "cargo-platform"
@@ -3076,6 +3095,7 @@ version = "0.1.0"
 dependencies = [
  "async-channel",
  "bevy",
+ "bevy_embedded_assets",
  "bevy_mod_picking",
  "build-info",
  "build-info-build",

--- a/kodecks-bevy/Cargo.toml
+++ b/kodecks-bevy/Cargo.toml
@@ -7,6 +7,7 @@ default-run = "kodecks-bevy"
 [dependencies]
 async-channel = "2.3.1"
 bevy = "0.14.1"
+bevy_embedded_assets = { version = "0.11.0", optional = true }
 bevy_mod_picking = { version = "0.20.1", features = [
     "backend_raycast",
     "backend_bevy_ui",
@@ -48,3 +49,4 @@ build-info-build = "0.0.38"
 [features]
 trace_chrome = ["trace", "bevy/trace_chrome"]
 trace = []
+embed_assets = ["bevy_embedded_assets"]

--- a/kodecks-bevy/src/main.rs
+++ b/kodecks-bevy/src/main.rs
@@ -9,6 +9,13 @@ mod scene;
 fn main() {
     let mut app = App::new();
 
+    #[cfg(feature = "embed_assets")]
+    let app = app.add_plugins(bevy_embedded_assets::EmbeddedAssetPlugin {
+        mode: bevy_embedded_assets::PluginMode::ReplaceAndFallback {
+            path: "assets".to_string(),
+        },
+    });
+
     let default_plugins = DefaultPlugins
         .set(ImagePlugin::default_nearest())
         .set(WindowPlugin {


### PR DESCRIPTION
This pull request adds the `embed_assets` feature flag to the project. It includes changes to the `Cargo.toml` file, adding the `bevy_embedded_assets` crate as an optional dependency. It also includes changes to the `main.rs` file, where the `embed_assets` feature is conditionally enabled, and the `bevy_embedded_assets::EmbeddedAssetPlugin` is added to the app's plugins when the feature is enabled.