### PR TITLE
Add creature types to card definitions

### DIFF
--- a/kodecks-catalog/src/cards/airborne_eagle_ray.rs
+++ b/kodecks-catalog/src/cards/airborne_eagle_ray.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::BLUE,
     cost: 3,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Cyborg,
     power: 300,
 );
 

--- a/kodecks-catalog/src/cards/ant.rs
+++ b/kodecks-catalog/src/cards/ant.rs
@@ -7,6 +7,7 @@ card_def!(
     "Ant",
     color: Color::GREEN,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 100,
     is_token: true,
 );

--- a/kodecks-catalog/src/cards/bambooster.rs
+++ b/kodecks-catalog/src/cards/bambooster.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::RED,
     cost: 1,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Robot,
     power: 300,
 );
 

--- a/kodecks-catalog/src/cards/binary_starfish.rs
+++ b/kodecks-catalog/src/cards/binary_starfish.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::BLUE,
     cost: 3,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 200,
 );
 

--- a/kodecks-catalog/src/cards/coppermine_scorpion.rs
+++ b/kodecks-catalog/src/cards/coppermine_scorpion.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::RED,
     cost: 2,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Robot,
     power: 200,
     abilities: &[KeywordAbility::Toxic][..],
 );

--- a/kodecks-catalog/src/cards/deep_sea_wyrm.rs
+++ b/kodecks-catalog/src/cards/deep_sea_wyrm.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::BLUE,
     cost: 6,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 500,
     abilities: &[KeywordAbility::Stealth][..],
 );

--- a/kodecks-catalog/src/cards/diamond_porcupine.rs
+++ b/kodecks-catalog/src/cards/diamond_porcupine.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::RED,
     cost: 2,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Cyborg,
     power: 100,
     shields: 1,
 );

--- a/kodecks-catalog/src/cards/flash_bang_jellyfish.rs
+++ b/kodecks-catalog/src/cards/flash_bang_jellyfish.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::BLUE,
     cost: 3,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Cyborg,
     power: 300,
 );
 

--- a/kodecks-catalog/src/cards/graphite_armadillo.rs
+++ b/kodecks-catalog/src/cards/graphite_armadillo.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::RED,
     cost: 2,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 200,
     shields: 1,
 );

--- a/kodecks-catalog/src/cards/helium_puffer.rs
+++ b/kodecks-catalog/src/cards/helium_puffer.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::BLUE,
     cost: 1,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Cyborg,
     power: 200,
 );
 

--- a/kodecks-catalog/src/cards/laser_frog.rs
+++ b/kodecks-catalog/src/cards/laser_frog.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::RED,
     cost: 2,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Cyborg,
     power: 100,
 );
 

--- a/kodecks-catalog/src/cards/mire_alligator.rs
+++ b/kodecks-catalog/src/cards/mire_alligator.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::GREEN,
     cost: 3,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 400,
 );
 

--- a/kodecks-catalog/src/cards/moonlit_gecko.rs
+++ b/kodecks-catalog/src/cards/moonlit_gecko.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::GREEN,
     cost: 0,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 100,
 );
 

--- a/kodecks-catalog/src/cards/moss_grown_mastodon.rs
+++ b/kodecks-catalog/src/cards/moss_grown_mastodon.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::GREEN,
     cost: 7,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 700,
     shields: 1,
 );

--- a/kodecks-catalog/src/cards/oil_leaking_droid.rs
+++ b/kodecks-catalog/src/cards/oil_leaking_droid.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::RED,
     cost: 2,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Robot,
     power: 100,
     abilities: &[KeywordAbility::Toxic][..],
 );

--- a/kodecks-catalog/src/cards/pyrosnail.rs
+++ b/kodecks-catalog/src/cards/pyrosnail.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::RED,
     cost: 2,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Cyborg,
     power: 100,
     abilities: &[KeywordAbility::Volatile][..],
 );

--- a/kodecks-catalog/src/cards/radio_deer.rs
+++ b/kodecks-catalog/src/cards/radio_deer.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::GREEN,
     cost: 3,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Cyborg,
     power: 200,
     shields: 1,
 );

--- a/kodecks-catalog/src/cards/scrapyard_raven.rs
+++ b/kodecks-catalog/src/cards/scrapyard_raven.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::GREEN,
     cost: 2,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 200,
 );
 

--- a/kodecks-catalog/src/cards/turbofish.rs
+++ b/kodecks-catalog/src/cards/turbofish.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::BLUE,
     cost: 0,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 100,
 );
 

--- a/kodecks-catalog/src/cards/vigilant_lynx.rs
+++ b/kodecks-catalog/src/cards/vigilant_lynx.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::GREEN,
     cost: 2,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 100,
     shields: 1,
 );

--- a/kodecks-catalog/src/cards/volcanic_wyrm.rs
+++ b/kodecks-catalog/src/cards/volcanic_wyrm.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::RED,
     cost: 7,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 500,
     shields: 1,
 );

--- a/kodecks-catalog/src/cards/voracious_anteater.rs
+++ b/kodecks-catalog/src/cards/voracious_anteater.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::GREEN,
     cost: 3,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Cyborg,
     power: 400,
 );
 

--- a/kodecks-catalog/src/cards/wasteland_cobra.rs
+++ b/kodecks-catalog/src/cards/wasteland_cobra.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::GREEN,
     cost: 1,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 200,
 );
 

--- a/kodecks-catalog/src/cards/wind_up_spider.rs
+++ b/kodecks-catalog/src/cards/wind_up_spider.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::RED,
     cost: 0,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Robot,
     power: 100,
 );
 

--- a/kodecks-catalog/src/cards/zigzag_ammonite.rs
+++ b/kodecks-catalog/src/cards/zigzag_ammonite.rs
@@ -8,6 +8,7 @@ card_def!(
     color: Color::BLUE,
     cost: 2,
     card_type: CardType::Creature,
+    creature_type: CreatureType::Mutant,
     power: 300,
 );
 

--- a/kodecks/src/card.rs
+++ b/kodecks/src/card.rs
@@ -393,6 +393,7 @@ pub struct CardAttribute {
     pub color: Color,
     pub cost: u8,
     pub card_type: CardType,
+    pub creature_type: Option<CreatureType>,
     pub abilities: &'static [KeywordAbility],
     pub anon_abilities: &'static [AnonymousAbility],
     pub power: Option<u32>,
@@ -406,6 +407,7 @@ impl Default for CardAttribute {
             color: Color::COLORLESS,
             cost: 0,
             card_type: CardType::Hex,
+            creature_type: None,
             abilities: &[],
             anon_abilities: &[],
             power: None,
@@ -420,4 +422,14 @@ impl Default for CardAttribute {
 pub enum CardType {
     Creature,
     Hex,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CreatureType {
+    Mutant,
+    Cyborg,
+    Robot,
+    Ghost,
+    Program,
 }

--- a/kodecks/src/computed.rs
+++ b/kodecks/src/computed.rs
@@ -1,6 +1,6 @@
 use crate::{
     ability::{AbilityList, AnonymousAbility, KeywordAbility},
-    card::{Card, CardArchetype, CardType},
+    card::{Card, CardArchetype, CardType, CreatureType},
     color::Color,
     linear::Linear,
     zone::CardZone,
@@ -13,6 +13,7 @@ pub struct ComputedAttribute {
     pub color: Color,
     pub cost: Linear<u8>,
     pub card_type: CardType,
+    pub creature_type: Option<CreatureType>,
     pub abilities: AbilityList<KeywordAbility>,
     pub anon_abilities: AbilityList<AnonymousAbility>,
     pub power: Option<Linear<u32>>,
@@ -25,6 +26,7 @@ impl From<&CardArchetype> for ComputedAttribute {
             color: archetype.attribute.color,
             cost: archetype.attribute.cost.into(),
             card_type: archetype.attribute.card_type,
+            creature_type: archetype.attribute.creature_type,
             abilities: archetype.attribute.abilities.iter().copied().collect(),
             anon_abilities: archetype.attribute.anon_abilities.iter().copied().collect(),
             power: archetype.attribute.power.map(Linear::from),


### PR DESCRIPTION
This pull request adds creature types to the card definitions in the codebase. Each card now has a `creature_type` field that specifies the type of creature it represents, such as Mutant, Cyborg, Robot, Ghost, or Program. This information will be used for gameplay mechanics and card interactions.