### PR TITLE
Run local game logic asynchronously

### DIFF
--- a/kodecks-engine/src/game.rs
+++ b/kodecks-engine/src/game.rs
@@ -1,5 +1,8 @@
 use crate::message::{GameCommand, GameCommandKind, GameEvent, GameEventKind, Output};
-use futures::channel::mpsc::Sender;
+use futures::{
+    channel::mpsc::{Receiver, Sender},
+    SinkExt, StreamExt,
+};
 use kodecks::{
     action::{Action, PlayerAvailableActions},
     env::{Environment, LocalGameState},
@@ -69,24 +72,6 @@ impl Game {
         self.progress();
     }
 
-    fn send_player_thinking(&self, thinking: u8) {
-        for player in self.players().filter(|&p| p != thinking) {
-            let event = GameEvent {
-                game_id: self.id,
-                player,
-                event: GameEventKind::PlayerThinking {
-                    thinking,
-                    timeout: None,
-                },
-            };
-            self.sender
-                .lock()
-                .unwrap()
-                .try_send(Output::GameEvent(event))
-                .unwrap();
-        }
-    }
-
     fn progress(&mut self) {
         while !self.env.game_condition().is_ended() {
             let conceded = self
@@ -102,7 +87,6 @@ impl Game {
                     .iter()
                     .any(|bot| bot.player == self.player_in_action);
                 if is_bot {
-                    self.send_player_thinking(self.player_in_action);
                     let env = self.env.clone();
                     (
                         self.player_in_action,
@@ -111,7 +95,6 @@ impl Game {
                 } else if let Some(action) = self.next_actions.remove(&self.player_in_action) {
                     (self.player_in_action, Some(action))
                 } else {
-                    self.send_player_thinking(self.player_in_action);
                     return;
                 }
             } else {
@@ -159,4 +142,118 @@ impl Game {
     pub fn is_ended(&self) -> bool {
         self.env.game_condition().is_ended()
     }
+}
+
+pub async fn start_game(
+    log_id: String,
+    profile: GameProfile,
+    mut receiver: Receiver<GameCommand>,
+    mut sender: Sender<Output>,
+) {
+    let bots = profile.bots.clone();
+    let mut players = profile
+        .players
+        .iter()
+        .enumerate()
+        .map(|(id, _)| PlayerData {
+            id: id as u8,
+            bot: if bots.iter().any(|bot| bot.player == id as u8) {
+                Some(DefaultBot::builder().build())
+            } else {
+                None
+            },
+            next_action: None,
+        })
+        .collect::<Vec<_>>();
+
+    let mut env = Arc::new(Environment::new(profile, &CATALOG));
+    let mut available_actions: Option<PlayerAvailableActions> = None;
+    let mut player_in_action = env.state.players.player_in_turn().id;
+
+    for player in &players {
+        if player.bot.is_none() {
+            sender
+                .send(Output::GameEvent(GameEvent {
+                    game_id: 0,
+                    player: player.id,
+                    event: GameEventKind::Created {
+                        log_id: log_id.clone(),
+                    },
+                }))
+                .await
+                .unwrap();
+        }
+    }
+
+    while !env.game_condition().is_ended() {
+        if let Some(available_actions) = &available_actions {
+            if players[available_actions.player as usize].bot.is_none() {
+                if let Some(command) = receiver.next().await {
+                    match command.kind {
+                        GameCommandKind::NextAction { action } => {
+                            players[command.player as usize].next_action = Some(action);
+                        }
+                    }
+                }
+            }
+        }
+
+        while !env.game_condition().is_ended() {
+            let conceded = players
+                .iter()
+                .find(|data| matches!(data.next_action, Some(Action::Concede)))
+                .map(|data| data.id);
+            let (player, next_action) = if let Some(player) = conceded {
+                (player, Some(Action::Concede))
+            } else if let Some(available_actions) = &available_actions {
+                if let Some(bot) = players[player_in_action as usize].bot.as_mut() {
+                    let env = env.clone();
+                    (
+                        player_in_action,
+                        bot.compute_best_action(env, available_actions),
+                    )
+                } else if let Some(action) = players[player_in_action as usize].next_action.take() {
+                    (player_in_action, Some(action))
+                } else {
+                    break;
+                }
+            } else {
+                (player_in_action, None)
+            };
+
+            let report = Arc::make_mut(&mut env).process(player, next_action);
+            available_actions.clone_from(&report.available_actions);
+
+            if let Some(available_actions) = &report.available_actions {
+                player_in_action = available_actions.player;
+            }
+
+            for player in &players {
+                if player.bot.is_none() {
+                    let state = LocalGameState {
+                        env: env.local(player.id, LocalStateAccess::Player(player.id)),
+                        logs: report.logs.clone(),
+                        available_actions: report
+                            .available_actions
+                            .clone()
+                            .filter(|actions| actions.player == player.id),
+                    };
+                    let event = GameEvent {
+                        game_id: 0,
+                        player: player.id,
+                        event: GameEventKind::StateUpdated { state },
+                    };
+
+                    sender.send(Output::GameEvent(event)).await.unwrap();
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PlayerData {
+    id: u8,
+    bot: Option<DefaultBot>,
+    next_action: Option<Action>,
 }

--- a/kodecks-engine/src/lib.rs
+++ b/kodecks-engine/src/lib.rs
@@ -1,9 +1,3 @@
-use futures::channel::mpsc::Sender;
-use game::Game;
-use kodecks::profile::GameProfile;
-use message::{Command, Input, Output};
-use std::collections::HashMap;
-
 pub mod game;
 pub mod login;
 pub mod message;
@@ -11,48 +5,6 @@ pub mod room;
 pub mod user;
 pub mod version;
 pub mod worker;
-
-pub struct Engine {
-    game_counter: u32,
-    games: HashMap<u32, Game>,
-    sender: Sender<Output>,
-}
-
-impl Engine {
-    pub fn new(sender: Sender<Output>) -> Self {
-        Self {
-            game_counter: 0,
-            games: HashMap::new(),
-            sender,
-        }
-    }
-
-    pub fn handle_input(&mut self, input: message::Input) {
-        match input {
-            Input::Command(Command::CreateGame { log_id, profile }) => {
-                self.create_game(log_id, profile);
-            }
-            Input::GameCommand(session_command) => {
-                let id = session_command.game_id;
-                if let Some(session) = self.games.get_mut(&id) {
-                    session.process_command(session_command);
-                    if session.is_ended() {
-                        self.games.remove(&id);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    fn create_game(&mut self, log_id: String, profile: GameProfile) {
-        let game_id = self.game_counter;
-        self.game_counter += 1;
-
-        let game = Game::new(log_id, profile, self.sender.clone());
-        self.games.insert(game_id, game);
-    }
-}
 
 pub trait Connection {
     fn send(&mut self, output: message::Input);


### PR DESCRIPTION
This pull request updates the code to run the local game logic asynchronously. It introduces a new function `start_task` that handles the asynchronous processing of game commands. The `LocalEngine` struct now spawns a task using the `AsyncComputeTaskPool` to run the game logic asynchronously. Additionally, the `Engine` struct and related code have been removed as they are no longer needed.