### PR TITLE
Show human-readable translated game logs

### DIFF
--- a/kodecks-bevy/assets/locales/en-US/main.ftl
+++ b/kodecks-bevy/assets/locales/en-US/main.ftl
@@ -49,3 +49,190 @@ error-failed-to-connect-server = Failed to connect to the server.
 error-client-version-outdated = Your client needs to be updated.　Supported client version: { $requirement }
 error-server-version-outdated = The server needs to be updated. Supported client version: { $requirement }
 error-invalid-deck = Your deck does not meet the regulations.
+
+log-game-started = The game has started.
+
+log-game-ended = {$winner ->
+    [you] You
+    [opponent] Your opponent
+    *[other] {$winner}
+} won the game.
+
+log-game-draw = The game ended in a draw.
+
+log-turn-changed = {$player ->
+    [you] Your turn. (Turn {$turn})
+    [opponent] Opponent's turn. (Turn {$turn})
+   *[other] {$player}'s turn. (Turn {$turn})
+}
+
+log-phase-changed = {$phase ->
+    [standby] Standby Phase started.
+    [draw] Draw Phase started.
+    [main] Main Phase started.
+    [block] Block Phase started.
+    [battle] Battle Phase started.
+    [end] End Phase started.
+    *[other] {$phase} started.
+}
+
+log-life-changed = {$player ->
+    [you] Your life is {$life}.
+    [opponent] Your opponent's life is {$life}.
+   *[other] {$player}'s life is {$life}.
+}
+
+log-damage-taken = {$player ->
+    [you] You take {$amount} damage.
+    [opponent] Your opponent takes {$amount} damage.
+    *[other] {$player} takes {$amount} damage.
+}
+
+log-deck-shuffled = {$player ->
+    [you] Your deck has been shuffled.
+    [opponent] Your opponent's deck has been shuffled.
+    *[other] {$player}'s deck has been shuffled.
+}
+
+log-effect-activated = <<{$source}>>'s effect is activated.
+
+log-card-moved = {$card ->
+    [unknown] {$player ->
+        [you] Your card
+        [opponent] Your opponent's card
+        *[other] {$player}'s card
+    }
+    *[other] <<{$card}>>
+} is moved from {$from-player ->
+    [you] your
+    [opponent] your opponent's
+    *[other] {$from-player}'s
+} {$from-zone ->
+    [deck] deck
+    [hand] hand
+    [field] field
+    [graveyard] graveyard
+    *[other] {$from-zone}
+} to {$to-player ->
+    [you] your
+    [opponent] your opponent's
+    *[other] {$to-player}'s
+} {$to-zone ->
+    [deck] deck
+    [hand] hand
+    [field] field
+    [graveyard] graveyard
+    *[other] {$to-zone}
+}.
+
+log-card-drawn = {$player ->
+    [you] You drew
+    [opponent] Your opponent drew
+    *[other] {$player} drew
+} {$card ->
+    [unknown] a card
+    *[other] <<{$card}>>
+}.
+
+log-card-played = {$player ->
+    [you] You played
+    [opponent] Your opponent played
+    *[other] {$player} played
+} {$card ->
+    [unknown] a card
+    *[other] <<{$card}>>
+}.
+
+log-card-destroyed-to-graveyard = {$card ->
+    [unknown] {$player ->
+        [you] Your card
+        [opponent] Your opponent's card
+        *[other] {$player}'s card
+    }
+    *[other] <<{$card}>>
+} is destroyed and sent to the graveyard.
+
+log-card-discarded = {$player ->
+    [you] You discarded
+    [opponent] Your opponent discarded
+    *[other] {$player} discarded
+} {$card ->
+    [unknown] a card
+    *[other] <<{$card}>>
+}.
+
+log-card-targeted = {$source ->
+    [unknown] A card
+    *[other] <<{$source}>>
+} targeted {$target ->
+    [unknown] a card
+    *[other] <<{$target}>>
+}.
+
+log-card-token-generated = {$card ->
+    [unknown] A token
+    *[other] <<{$card}>> token
+} is generated.
+
+log-card-token-destroyed = {$card ->
+    [unknown] A token
+    *[other] <<{$card}>> token
+} is destroyed.
+
+log-shards-earned = {$player ->
+    [you] You earned
+    [opponent] Your opponent earned
+    *[other] {$player} earned
+} {$amount ->
+    [1] a
+    *[other] {$amount}
+} {$color ->
+    [red] red
+    [yellow] yellow
+    [green] green
+    [blue] blue
+    *[other] colorless
+} {$amount ->
+    [1] shard
+    *[other] shards
+}.
+
+log-shards-spent = {$player ->
+    [you] You spent
+    [opponent] Your opponent spent
+    *[other] {$player} spent
+} {$amount ->
+    [1] a
+    *[other] {$amount}
+} {$color ->
+    [red] red
+    [yellow] yellow
+    [green] green
+    [blue] blue
+    *[other] colorless
+} {$amount ->
+    [1] shard
+    *[other] shards
+}.
+
+log-creature-attacked-creature = {$attacker ->
+    [unknown] A creature
+    *[other] <<{$attacker}>>
+} attacked {$blocker ->
+    [unknown] a creature
+    *[other] <<{$blocker}>>
+}.
+
+log-creature-attacked-player = {$attacker ->
+    [unknown] A creature
+    *[other] <<{$attacker}>>
+} attacked {$player ->
+    [you] you
+    [opponent] your opponent
+    *[other] {$player}
+}.
+
+log-attack-declared = {$attacker ->
+    [unknown] A creature
+    *[other] <<{$attacker}>>
+} declared an attack.

--- a/kodecks-bevy/assets/locales/ja-JP/main.ftl
+++ b/kodecks-bevy/assets/locales/ja-JP/main.ftl
@@ -49,3 +49,178 @@ error-failed-to-connect-server = サーバーに接続できませんでした�
 error-client-version-outdated = クライアントのアップデートが必要です。対応クライアントバージョン: { $requirement }
 error-server-version-outdated = サーバーのアップデートが必要です。対応クライアントバージョン: { $requirement }
 error-invalid-deck = デッキがレギュレーションに適合していません。
+
+log-game-started = ゲームが開始されました。
+
+log-game-ended = {$winner ->
+    [you] あなた
+    [opponent] 対戦相手
+    *[other] {$winner}
+}がゲームに勝利しました。
+
+log-game-draw = ゲームは引き分けです。
+
+log-turn-changed = {$player ->
+    [you] あなたのターンです。(ターン{$turn})
+    [opponent] 相手のターンです。(ターン{$turn})
+   *[other] {$player}のターンです。(ターン{$turn})
+}
+
+log-phase-changed = {$phase ->
+    [standby] スタンバイフェイズを開始します。
+    [draw] ドローフェイズを開始します。
+    [main] メインフェイズを開始します。
+    [block] ブロックフェイズを開始します。
+    [battle] バトルフェイズを開始します。
+    [end] エンドフェイズを開始します。
+    *[other] {$phase}を開始します。
+}
+
+log-life-changed = {$player ->
+    [you] あなたのライフは{$life}です。
+    [opponent] 相手のライフは{$life}です。
+   *[other] {$player}のライフは{$life}です。
+}
+
+log-damage-taken = {$player ->
+    [you] あなたは{$amount}ダメージを受けました。
+    [opponent] 相手は{$amount}ダメージを受けました。
+    *[other] {$player}は{$amount}ダメージを受けました。
+}
+
+log-deck-shuffled = {$player ->
+    [you] あなたのデッキがシャッフルされました。
+    [opponent] 相手のデッキがシャッフルされました。
+    *[other] {$player}のデッキがシャッフルされました。
+}
+
+log-effect-activated = <<{$source}>>の効果が発動しました。
+
+log-card-moved = {$card ->
+    [unknown] {$player ->
+        [you] あなたのカード
+        [opponent] 対戦相手のカード
+        *[other] {$player}のカード
+    }
+    *[other] <<{$card}>>
+}は{$from-player ->
+    [you] あなたの
+    [opponent] 対戦相手の
+    *[other] {$from-player}の
+}{$from-zone ->
+    [deck] デッキ
+    [hand] 手札
+    [field] フィールド
+    [graveyard] 墓地
+    *[other] {$from-zone}
+}から{$to-player ->
+    [you] あなたの
+    [opponent] 対戦相手の
+    *[other] {$to-player}の
+}{$to-zone ->
+    [deck] デッキ
+    [hand] 手札
+    [field] フィールド
+    [graveyard] 墓地
+    *[other] {$to-zone}
+}に移動しました。
+
+log-card-drawn = {$player ->
+    [you] あなたが
+    [opponent] 対戦相手が
+    *[other] {$player}が
+}{$card ->
+    [unknown] カードを引きました
+    *[other] <<{$card}>>を引きました
+}。
+
+log-card-played = {$player ->
+    [you] あなたが
+    [opponent] 対戦相手が
+    *[other] {$player}が
+}{$card ->
+    [unknown] カード
+    *[other] <<{$card}>>
+}をプレイしました。
+
+log-card-destroyed-to-graveyard = {$card ->
+    [unknown] {$player ->
+        [you] あなたのカード
+        [opponent] 対戦相手のカード
+        *[other] {$player}のカード
+    }
+    *[other] <<{$card}>>
+}は破壊され墓地に送られました。
+
+log-card-discarded = {$player ->
+    [you] あなたが
+    [opponent] 対戦相手が
+    *[other] {$player}が
+}{$card ->
+    [unknown] カード
+    *[other] <<{$card}>>
+}を捨てました。
+
+log-card-targeted = {$source ->
+    [unknown] カード
+    *[other] <<{$source}>>
+}は{$target ->
+    [unknown] カード
+    *[other] <<{$target}>>
+}を対象にしました。
+
+log-card-token-generated = {$card ->
+    [unknown] トークン
+    *[other] <<{$card}>>トークン
+}が生成されました。
+
+log-card-token-destroyed = {$card ->
+    [unknown] トークン
+    *[other] <<{$card}>>トークン
+}が破壊されました。
+
+log-shards-earned = {$player ->
+    [you] あなたは
+    [opponent] 対戦相手は
+    *[other] {$player}は
+}{$color ->
+    [red] 赤
+    [yellow] 黄
+    [green] 緑
+    [blue] 青
+    *[other] 無色
+}のカケラを{$amount}つ獲得しました。
+
+log-shards-spent = {$player ->
+    [you] あなたは
+    [opponent] 対戦相手は
+    *[other] {$player}は
+}{$color ->
+    [red] 赤
+    [yellow] 黄
+    [green] 緑
+    [blue] 青
+    *[other] 無色
+}のカケラを{$amount}つ消費しました。
+
+log-creature-attacked-creature = {$attacker ->
+    [unknown] クリーチャー
+    *[other] <<{$attacker}>>
+}が{$blocker ->
+    [unknown] クリーチャー
+    *[other] <<{$blocker}>>
+}に攻撃しました。
+
+log-creature-attacked-player = {$attacker ->
+    [unknown] クリーチャー
+    *[other] <<{$attacker}>>
+}が{$player ->
+    [you] あなた
+    [opponent] 対戦相手
+    *[other] {$player}
+}に攻撃しました。
+
+log-attack-declared = {$attacker ->
+    [unknown] クリーチャー
+    *[other] <<{$attacker}>>
+}が攻撃を宣言しました。

--- a/kodecks-bevy/src/scene/game/log.rs
+++ b/kodecks-bevy/src/scene/game/log.rs
@@ -1,0 +1,295 @@
+use crate::scene::translator::Translator;
+use fluent_bundle::FluentArgs;
+use fluent_content::Request;
+use kodecks::{
+    card::Catalog,
+    env::LocalEnvironment,
+    log::LogAction,
+    zone::{MoveReason, Zone},
+};
+use std::borrow::Cow;
+
+pub fn translate_log<'a>(
+    action: &LogAction,
+    env: &LocalEnvironment,
+    catalog: &Catalog,
+    translator: &Translator,
+) -> Option<Cow<'a, str>> {
+    let mut args = FluentArgs::new();
+    let id = match action {
+        LogAction::GameStarted => "log-game-started",
+        LogAction::GameEnded { winner, .. } => {
+            if let Some(winner) = winner {
+                args.set(
+                    "winner",
+                    if *winner == env.player {
+                        "you"
+                    } else {
+                        "opponent"
+                    },
+                );
+                "log-game-ended"
+            } else {
+                "log-game-ended-draw"
+            }
+        }
+        LogAction::TurnChanged { player, turn } => {
+            args.set(
+                "player",
+                if *player == env.player {
+                    "you"
+                } else {
+                    "opponent"
+                },
+            );
+            args.set("turn", turn);
+            "log-turn-changed"
+        }
+        LogAction::PhaseChanged { phase } => {
+            args.set("phase", phase.to_string().to_ascii_lowercase());
+            "log-phase-changed"
+        }
+        LogAction::LifeChanged { player, life } => {
+            args.set(
+                "player",
+                if *player == env.player {
+                    "you"
+                } else {
+                    "opponent"
+                },
+            );
+            args.set("life", life);
+            "log-life-changed"
+        }
+        LogAction::DamageTaken { player, amount } => {
+            args.set(
+                "player",
+                if *player == env.player {
+                    "you"
+                } else {
+                    "opponent"
+                },
+            );
+            args.set("amount", amount);
+            "log-damage-taken"
+        }
+        LogAction::DeckShuffled { player } => {
+            args.set(
+                "player",
+                if *player == env.player {
+                    "you"
+                } else {
+                    "opponent"
+                },
+            );
+            "log-deck-shuffled"
+        }
+        LogAction::EffectActivated { source, .. } => {
+            if let Ok(card) = env.find_card(*source) {
+                let source = translator
+                    .get(&format!("card-{}", catalog[card.archetype_id].safe_name))
+                    .to_string();
+                args.set("source", source);
+            }
+            "log-effect-activated"
+        }
+        LogAction::CardMoved {
+            player,
+            card,
+            from,
+            to,
+            reason,
+        } => {
+            args.set(
+                "player",
+                if *player == env.player {
+                    "you"
+                } else {
+                    "opponent"
+                },
+            );
+            if let Some(card) = env
+                .find_card(*card)
+                .ok()
+                .filter(|card| !card.archetype_id.is_empty())
+            {
+                let card = translator
+                    .get(&format!("card-{}", catalog[card.archetype_id].safe_name))
+                    .to_string();
+                args.set("card", card);
+            } else {
+                args.set("card", "unknown");
+            }
+            match reason {
+                MoveReason::Draw => "log-card-drawn",
+                MoveReason::Casted => "log-card-played",
+                MoveReason::Destroyed if to.zone == Zone::Graveyard => {
+                    "log-card-destroyed-to-graveyard"
+                }
+                MoveReason::Discarded => "log-card-discarded",
+                _ => {
+                    args.set(
+                        "from-player",
+                        if from.player == env.player {
+                            "you"
+                        } else {
+                            "opponent"
+                        },
+                    );
+                    args.set("from-zone", from.zone.to_string().to_ascii_lowercase());
+                    args.set(
+                        "to-player",
+                        if to.player == env.player {
+                            "you"
+                        } else {
+                            "opponent"
+                        },
+                    );
+                    args.set("to-zone", to.zone.to_string().to_ascii_lowercase());
+                    "log-card-moved"
+                }
+            }
+        }
+        LogAction::CardTargeted { source, target } => {
+            if let Ok(card) = env.find_card(*source) {
+                let source = translator
+                    .get(&format!("card-{}", catalog[card.archetype_id].safe_name))
+                    .to_string();
+                args.set("source", source);
+            } else {
+                args.set("source", "unknown");
+            }
+            if let Ok(card) = env.find_card(*target) {
+                let target = translator
+                    .get(&format!("card-{}", catalog[card.archetype_id].safe_name))
+                    .to_string();
+                args.set("target", target);
+            } else {
+                args.set("target", "unknown");
+            }
+            "log-card-targeted"
+        }
+        LogAction::ShardsEarned {
+            player,
+            color,
+            amount,
+            ..
+        } => {
+            args.set(
+                "player",
+                if *player == env.player {
+                    "you"
+                } else {
+                    "opponent"
+                },
+            );
+            args.set("color", color.to_string().to_ascii_lowercase());
+            args.set("amount", amount);
+            "log-shards-earned"
+        }
+        LogAction::ShardsSpent {
+            player,
+            color,
+            amount,
+            ..
+        } => {
+            args.set(
+                "player",
+                if *player == env.player {
+                    "you"
+                } else {
+                    "opponent"
+                },
+            );
+            args.set("color", color.to_string().to_ascii_lowercase());
+            args.set("amount", amount);
+            "log-shards-spent"
+        }
+        LogAction::CardTokenGenerated { card } => {
+            if let Ok(card) = env.find_card(*card) {
+                let card = translator
+                    .get(&format!("card-{}", catalog[card.archetype_id].safe_name))
+                    .to_string();
+                args.set("card", card);
+            } else {
+                args.set("card", "unknown");
+            }
+            "log-card-token-generated"
+        }
+        LogAction::CardTokenDestroyed { card } => {
+            if let Ok(card) = env.find_card(*card) {
+                let card = translator
+                    .get(&format!("card-{}", catalog[card.archetype_id].safe_name))
+                    .to_string();
+                args.set("card", card);
+            } else {
+                args.set("card", "unknown");
+            }
+            "log-card-token-destroyed"
+        }
+        LogAction::AttackDeclared { attacker } => {
+            if let Ok(attacker) = env.find_card(*attacker) {
+                let attacker = translator
+                    .get(&format!(
+                        "card-{}",
+                        catalog[attacker.archetype_id].safe_name
+                    ))
+                    .to_string();
+                args.set("attacker", attacker);
+            } else {
+                args.set("attacker", "unknown");
+            }
+            "log-attack-declared"
+        }
+        LogAction::CreatureAttackedCreature { attacker, blocker } => {
+            if let Ok(attacker) = env.find_card(*attacker) {
+                let attacker = translator
+                    .get(&format!(
+                        "card-{}",
+                        catalog[attacker.archetype_id].safe_name
+                    ))
+                    .to_string();
+                args.set("attacker", attacker);
+            } else {
+                args.set("attacker", "unknown");
+            }
+            if let Ok(blocker) = env.find_card(*blocker) {
+                let blocker = translator
+                    .get(&format!("card-{}", catalog[blocker.archetype_id].safe_name))
+                    .to_string();
+                args.set("blocker", blocker);
+            } else {
+                args.set("blocker", "unknown");
+            }
+            "log-creature-attacked-creature"
+        }
+        LogAction::CreatureAttackedPlayer { attacker, player } => {
+            if let Ok(attacker) = env.find_card(*attacker) {
+                let attacker = translator
+                    .get(&format!(
+                        "card-{}",
+                        catalog[attacker.archetype_id].safe_name
+                    ))
+                    .to_string();
+                args.set("attacker", attacker);
+            } else {
+                args.set("attacker", "unknown");
+            }
+            args.set(
+                "player",
+                if *player == env.player {
+                    "you"
+                } else {
+                    "opponent"
+                },
+            );
+            "log-creature-attacked-player"
+        }
+        _ => return None,
+    };
+    Some(translator.get(Request {
+        id,
+        attr: None,
+        args: Some(args),
+    }))
+}

--- a/kodecks-bevy/src/scene/game/mod.rs
+++ b/kodecks-bevy/src/scene/game/mod.rs
@@ -3,6 +3,7 @@ pub mod camera;
 pub mod cleanup;
 pub mod event;
 pub mod loading;
+pub mod log;
 pub mod main;
 pub mod mode;
 pub mod result;

--- a/kodecks/src/env/opcode.rs
+++ b/kodecks/src/env/opcode.rs
@@ -280,10 +280,16 @@ impl Environment {
             Opcode::InflictDamage { player, amount } => {
                 let player = self.state.players.get_mut(player);
                 player.stats.life = player.stats.life.saturating_sub(amount);
-                Ok(vec![LogAction::DamageTaken {
-                    player: player.id,
-                    amount,
-                }])
+                Ok(vec![
+                    LogAction::DamageTaken {
+                        player: player.id,
+                        amount,
+                    },
+                    LogAction::LifeChanged {
+                        player: player.id,
+                        life: player.stats.life,
+                    },
+                ])
             }
         }
     }


### PR DESCRIPTION
This pull request adds the functionality to display human-readable translated game logs. It includes changes to the log module, the server events module, and the translation files for different languages. Now, when game events occur, such as the game starting, a turn changing, life being changed, damage being taken, cards being moved or played, and various other actions, the logs will be displayed in a translated format based on the selected language. This improves the user experience by providing clear and understandable game logs.