### PR TITLE
Update leafwing-input-manager to version 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "dyn-eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d035d21af5cde1a6f5c7b444a5bf963520a9f142e5d06931178433d7d5388"
+
+[[package]]
+name = "dyn-hash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a650a461c6a8ff1ef205ed9a2ad56579309853fecefc2423f73dced342f92258"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4082,22 +4094,27 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leafwing-input-manager"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebb7f3227809906ca7ccc981aedf7805b5edb422b4265290cc749316c0faba4"
+checksum = "4021fbf18a5ed42d81fe26d1976b11567db22ebb80baa06d05dcbd270d455c7e"
 dependencies = [
  "bevy",
  "derive_more",
+ "dyn-clone",
+ "dyn-eq",
+ "dyn-hash",
  "itertools 0.13.0",
  "leafwing_input_manager_macros",
+ "once_cell",
  "serde",
+ "serde_flexitos",
 ]
 
 [[package]]
 name = "leafwing_input_manager_macros"
-version = "0.13.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d065e4f0771d9cc597e76d648da18476ad01fd50cd60ee585ee500f9cd8d696"
+checksum = "c4e346fb74dc1ffceed58cdd5c88c6dd3f6548e77ac2beba6a37ff0b1a94b36a"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -5804,6 +5821,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "serde_flexitos"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323d093d7597660758b742dd7a1525539613f6182b306a4e1dd6e01a89bada9"
+dependencies = [
+ "erased-serde",
+ "serde",
 ]
 
 [[package]]

--- a/kodecks-bevy/Cargo.toml
+++ b/kodecks-bevy/Cargo.toml
@@ -42,7 +42,7 @@ kodecks = { path = "../kodecks" }
 kodecks-bot = { path = "../kodecks-bot" }
 kodecks-catalog = { path = "../kodecks-catalog" }
 kodecks-engine = { path = "../kodecks-engine" }
-leafwing-input-manager = "0.14.0"
+leafwing-input-manager = "0.15.1"
 log = { version = "0.4", features = [
     "max_level_debug",
     "release_max_level_warn",

--- a/kodecks-bevy/src/input.rs
+++ b/kodecks-bevy/src/input.rs
@@ -25,10 +25,13 @@ fn init(mut commands: Commands) {
         (UserAction::Block, KeyCode::KeyA),
         (UserAction::Continue, KeyCode::Space),
     ]);
-    input_map.insert_chord(UserAction::AllAttack, [KeyCode::ShiftLeft, KeyCode::KeyA]);
-    input_map.insert_chord(
+    input_map.insert(
+        UserAction::AllAttack,
+        ButtonlikeChord::new([KeyCode::ShiftLeft, KeyCode::KeyA]),
+    );
+    input_map.insert(
         UserAction::Concede,
-        [KeyCode::ShiftLeft, KeyCode::ControlLeft, KeyCode::KeyO],
+        ButtonlikeChord::new([KeyCode::ShiftLeft, KeyCode::ControlLeft, KeyCode::KeyO]),
     );
     commands.spawn(InputManagerBundle::with_map(input_map));
 }


### PR DESCRIPTION
This pull request updates the `leafwing-input-manager` dependency to version 0.15.1.