### PR TITLE
Upgrade web dependencies and enable web_sys_unstable_apis

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Download assets
         run: ./scripts/download.sh
       - name: Build
-        run: trunk build --release
+        run: trunk build --cargo-profile web-distribution
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v3.0
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,9 +3888,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3997,6 +3997,7 @@ dependencies = [
  "unic-langid",
  "url",
  "vergen-git2",
+ "web-sys",
 ]
 
 [[package]]
@@ -6951,9 +6952,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6962,9 +6963,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -6977,9 +6978,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6989,9 +6990,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6999,9 +7000,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7012,9 +7013,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wayland-backend"
@@ -7127,9 +7128,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members = [
     "kodecks-bevy",
     "kodecks-bot",
     "kodecks-catalog",
-    "kodecks-engine", "kodecks-server",
+    "kodecks-engine",
+    "kodecks-server",
 ]
 
 [profile.dev]
@@ -19,15 +20,14 @@ opt-level = 2
 [profile.dev.package.kodecks-bot]
 opt-level = 2
 
-[profile.release]
+[profile.distribution]
+inherits = "release"
+lto = "thin"
+
+[profile.web-distribution]
+inherits = "release"
 opt-level = 'z'
 panic = 'abort'
-debug = 0
 strip = true
 lto = true
 codegen-units = 1
-
-[profile.distribution]
-inherits = "release"
-opt-level = 3
-lto = "thin"

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -7,4 +7,4 @@ target = "web/index.html"
 no_spa = true
 
 [tools]
-wasm_bindgen = "0.2.93"
+wasm_bindgen = "0.2.95"

--- a/kodecks-bevy/Cargo.toml
+++ b/kodecks-bevy/Cargo.toml
@@ -70,6 +70,7 @@ bpaf = { version = "0.9", features = ["derive"] }
 [target.'cfg(target_family = "wasm")'.dependencies]
 gloo-storage = "0.3.0"
 sys-locale = { version = "0.3.1", features = ["js"] }
+web-sys = "0.3.72"
 
 [build-dependencies]
 anyhow = "1.0.89"

--- a/kodecks-engine/Cargo.toml
+++ b/kodecks-engine/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.210", features = ["derive"] }
 tracing = "0.1.40"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-wasm-bindgen-futures = "0.4.43"
+wasm-bindgen-futures = "0.4.45"
 getrandom = { version = "0.2", features = ["js"] }
 gloo-worker = { version = "0.5.0", features = ["futures"] }
 console_error_panic_hook = "0.1.7"


### PR DESCRIPTION
This pull request upgrades the web dependencies and enables the web_sys_unstable_apis feature. It adds the web-distribution profile to the .cargo/config.toml file and modifies the web-deploy.yml file to use the web-distribution profile when building.