### PR TITLE
Specify rustflags as a workflow env

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: --cfg=web_sys_unstable_apis
 
 jobs:
   build_wasm:

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: --cfg=web_sys_unstable_apis
 
 jobs:
   web-deploy:


### PR DESCRIPTION
This pull request adds the `RUSTFLAGS` environment variable to the workflow, with the value `--cfg=web_sys_unstable_apis`. This ensures that the `web_sys_unstable_apis` configuration flag is set when building the project.